### PR TITLE
[Easy-format] Also recursively inherit breaks if Never_wrap.

### DIFF
--- a/easy_format.ml
+++ b/easy_format.ml
@@ -135,6 +135,7 @@ let propagate_forced_breaks x =
     | List ((_, _, _, { wrap_body = `Force_breaks }), _) -> x, force_breaks
 
     | List ((op, sep, cl, ({ wrap_body = (`Wrap_atoms
+                                         | `Never_wrap
                                          | `Always_wrap) } as p)),
             children) ->
         if force_breaks then
@@ -143,7 +144,7 @@ let propagate_forced_breaks x =
         else
           x, false
 
-    | List ((_, _, _, { wrap_body = (`Never_wrap | `No_breaks) }), _)
+    | List ((_, _, _, { wrap_body = `No_breaks }), _)
     | Atom _
     | Label _
     | Custom _ -> x, force_breaks

--- a/simple_example.ml
+++ b/simple_example.ml
@@ -123,6 +123,36 @@ let format_function_definition (body_label, body_param) name param body =
   )
 
 (*
+   Illustrate the difference between `Force_break and `Force_breaks_rec on
+   labels.
+*)
+let labelOneAtom = Atom ("reallyLongLabelOne", atom)
+let labelTwoAtom = Atom ("reallyLongLabelTwo", atom)
+let labelThreeAtom = Atom ("reallyLongLabelABC", atom)
+let make_list_in_labels (wrap) =
+  Label (
+    (labelOneAtom, label),
+    (
+      Label (
+        (labelTwoAtom, label),
+        (
+          Label (
+            (labelThreeAtom, label),
+            List (
+              ("[", ",", "]", { list with wrap_body = wrap }),
+              [
+                Atom ("1.23456", atom);
+                Atom ("9.87654", atom);
+                Atom ("9.87654", atom);
+                Atom ("9.87654", atom);
+              ]
+            )
+          )
+        )
+      )
+    )
+  )
+(*
    Illustrate the difference between `Force_break and `Force_breaks_rec
 *)
 let make_heterogenous_list (container_wrap, wrap) =
@@ -169,6 +199,9 @@ let print_tuple fmt l =
 
 let print_heterogenous_list fmt wrap =
   Pretty.to_formatter fmt (make_heterogenous_list wrap)
+
+let print_list_in_labels fmt wrap =
+  Pretty.to_formatter fmt (make_list_in_labels wrap)
 
 let print_sum ?wrap fmt l =
   Pretty.to_formatter fmt (format_sum ?wrap l)
@@ -217,6 +250,21 @@ let () =
   print "no breaks outer list, inner list using `Force_breaks_rec";
   with_margin 80 print_heterogenous_list (`No_breaks, `Force_breaks_rec);
   with_margin 20 print_heterogenous_list (`No_breaks, `Force_breaks_rec);
+
+  print "label with inner list using `Force_breaks_rec";
+  with_margin 80 print_list_in_labels (`Force_breaks_rec);
+  with_margin 70 print_list_in_labels (`Force_breaks_rec);
+  with_margin 20 print_list_in_labels (`Force_breaks_rec);
+
+  print "label with inner list using `Force_breaks";
+  with_margin 80 print_list_in_labels (`Force_breaks);
+  with_margin 70 print_list_in_labels (`Force_breaks);
+  with_margin 20 print_list_in_labels (`Force_breaks);
+
+  print "label with inner list using `Never_wrap";
+  with_margin 80 print_list_in_labels (`Never_wrap);
+  with_margin 70 print_list_in_labels (`Never_wrap);
+  with_margin 20 print_list_in_labels (`Never_wrap);
 
   (* Triangular array of arrays showing wrapping of lists of atoms *)
   let m = Array.init 20 (fun i -> Array.init i (fun i -> sqrt (float i))) in

--- a/simple_example.ml
+++ b/simple_example.ml
@@ -125,9 +125,9 @@ let format_function_definition (body_label, body_param) name param body =
 (*
    Illustrate the difference between `Force_break and `Force_breaks_rec
 *)
-let make_heterogenous_list wrap =
+let make_heterogenous_list (container_wrap, wrap) =
   List (
-    ("[", ",", "]", { list with wrap_body = `Always_wrap }),
+    ("[", ",", "]", { list with wrap_body = container_wrap }),
     [
       Atom ("0", atom);
       List (
@@ -195,12 +195,28 @@ let () =
 
   (* Heterogenous list *)
   print "wrappable outer list, inner list using `Force_breaks";
-  with_margin 80 print_heterogenous_list `Force_breaks;
-  with_margin 20 print_heterogenous_list `Force_breaks;
+  with_margin 80 print_heterogenous_list (`Always_wrap, `Force_breaks);
+  with_margin 20 print_heterogenous_list (`Always_wrap, `Force_breaks);
 
   print "wrappable outer list, inner list using `Force_breaks_rec";
-  with_margin 80 print_heterogenous_list `Force_breaks_rec;
-  with_margin 20 print_heterogenous_list `Force_breaks_rec;
+  with_margin 80 print_heterogenous_list (`Always_wrap, `Force_breaks_rec);
+  with_margin 20 print_heterogenous_list (`Always_wrap, `Force_breaks_rec);
+
+  print "never_wrap outer list, inner list using `Force_breaks";
+  with_margin 80 print_heterogenous_list (`Never_wrap, `Force_breaks);
+  with_margin 20 print_heterogenous_list (`Never_wrap, `Force_breaks);
+
+  print "never_wrap outer list, inner list using `Force_breaks_rec";
+  with_margin 80 print_heterogenous_list (`Never_wrap, `Force_breaks_rec);
+  with_margin 20 print_heterogenous_list (`Never_wrap, `Force_breaks_rec);
+
+  print "no breaks outer list, inner list using `Force_breaks";
+  with_margin 80 print_heterogenous_list (`No_breaks, `Force_breaks);
+  with_margin 20 print_heterogenous_list (`No_breaks, `Force_breaks);
+
+  print "no breaks outer list, inner list using `Force_breaks_rec";
+  with_margin 80 print_heterogenous_list (`No_breaks, `Force_breaks_rec);
+  with_margin 20 print_heterogenous_list (`No_breaks, `Force_breaks_rec);
 
   (* Triangular array of arrays showing wrapping of lists of atoms *)
   let m = Array.init 20 (fun i -> Array.init i (fun i -> sqrt (float i))) in


### PR DESCRIPTION
Summary: Here's what the new test cases output.
```
*** wrappable outer list, inner list using `Force_breaks ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]
++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ], 1, 2, 3
]

*** wrappable outer list, inner list using `Force_breaks_rec ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ],
  1,
  2,
  3
]
++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ],
  1,
  2,
  3
]

*** never_wrap outer list, inner list using `Force_breaks ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]
++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ],
  1,
  2,
  3
]

*** never_wrap outer list, inner list using `Force_breaks_rec ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ],
  1,
  2,
  3
]
++++++++++++++++++++
[
  0,
  [
    1.23456,
    9.87654
  ],
  1,
  2,
  3
]

*** no breaks outer list, inner list using `Force_breaks ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]
++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]

*** no breaks outer list, inner list using `Force_breaks_rec ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]
++++++++++++++++++++
[ 0, [
       1.23456,
       9.87654
     ], 1, 2, 3 ]
```
CC:@jberdine