### PR TITLE
Jordan: Force breaks after labels if child requires so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ nativecode
 lambda_example
 simple_example
 test_easy_format
-
+easy_format_example.html
+easy_format_example.ml
+ocamldoc

--- a/easy_format.mli
+++ b/easy_format.mli
@@ -39,6 +39,19 @@ type wrap =
       i.e. never break line between list items
 *)
 
+type label_break = [
+  | `Auto
+  | `Always
+  | `Always_rec
+  | `Never
+]
+(** When to break the line after a [Label]:
+    - [Auto]: break after the label if there's not enough room
+    - [Always]: always break after the label
+    - [Always_rec]: always break after the label and force breaks in all parent
+      lists and labels, similarly to [`Force_breaks_rec] for lists.
+    - [Never]: never break after the label
+*)
 
 type style_name = string
 
@@ -116,14 +129,22 @@ val list : list_param
     See {!Easy_format.label}.
 *)
 type label_param = {
-  space_after_label : bool; (** Whether there must be some whitespace
-				after the label.
-				Default: [true] *)
-  indent_after_label : int; (** Extra indentation before the item
-				that comes after a label.
-				Default: [2]
-			    *)
-  label_style : style_name option; (** Default: [None] *)
+  label_break: label_break;
+    (** Whether to break the line after the label.
+        Introduced in version 1.2.0.
+        Default: [`Auto] *)
+
+  space_after_label : bool;
+    (** Whether there must be some whitespace after the label.
+	Default: [true] *)
+
+  indent_after_label : int;
+    (** Extra indentation before the item that comes after a label.
+	Default: [2]
+    *)
+
+  label_style : style_name option;
+    (** Default: [None] *)
 }
 
 val label : label_param

--- a/simple_example.ml
+++ b/simple_example.ml
@@ -126,18 +126,18 @@ let format_function_definition (body_label, body_param) name param body =
    Illustrate the difference between `Force_break and `Force_breaks_rec on
    labels.
 *)
-let labelOneAtom = Atom ("reallyLongLabelOne", atom)
-let labelTwoAtom = Atom ("reallyLongLabelTwo", atom)
-let labelThreeAtom = Atom ("reallyLongLabelABC", atom)
+let label_one_atom = Atom ("reallyLongLabelOne", atom)
+let label_two_atom = Atom ("reallyLongLabelTwo", atom)
+let label_three_atom = Atom ("reallyLongLabelABC", atom)
 let make_list_in_labels (wrap) =
   Label (
-    (labelOneAtom, label),
+    (label_one_atom, label),
     (
       Label (
-        (labelTwoAtom, label),
+        (label_two_atom, label),
         (
           Label (
-            (labelThreeAtom, label),
+            (label_three_atom, label),
             List (
               ("[", ",", "]", { list with wrap_body = wrap }),
               [
@@ -152,6 +152,7 @@ let make_list_in_labels (wrap) =
       )
     )
   )
+
 (*
    Illustrate the difference between `Force_break and `Force_breaks_rec
 *)


### PR DESCRIPTION
This generalizes the `Force_breaks_rec` feature to labels. I introduced a new label parameter called `label_break` which defines whether the break after the label is automatic (normal behavior), or should be forced.

Just like for lists, we can also force a break after a label and require a break in all the containing lists or labels.

The example posted in https://github.com/mjambon/easy-format/pull/8 now looks good (first case for the ``label with inner list using `Force_breaks_rec``):

```
*** label with inner list using `Force_breaks_rec ***
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
reallyLongLabelOne
  reallyLongLabelTwo
    reallyLongLabelABC [
      1.23456,
      9.87654,
      9.87654,
      9.87654
    ]
```

I didn't write tests or examples for the new `` `Always_rec`` or `` `Never``, but we should. I don't know if `` `Never`` will ever be useful, I added it primarily for completeness.