### PR TITLE
Limit stack usage

### DIFF
--- a/src/easy_format.ml
+++ b/src/easy_format.ml
@@ -7,13 +7,15 @@ module List = struct
   let map f l = List.rev_map f l |> List.rev
 
   (** Tail recursive version of split *)
-  let split l =
+  let rev_split l =
     let rec inner xs ys = function
       | (x, y) :: xys ->
           inner (x::xs) (y::ys) xys
       | [] -> (xs, ys)
     in
-    inner [] [] (List.rev l)
+    inner [] [] l
+
+  let split l = rev_split (List.rev l)
 
 end
 
@@ -125,7 +127,7 @@ let propagate_from_leaf_to_root
         let acc = init_acc x in
         map_node x acc
     | List (param, children) ->
-        let new_children, accs = List.split (List.map aux children) in
+        let new_children, accs = List.rev_split (List.rev_map aux children) in
         let acc = List.fold_left merge_acc (init_acc x) accs in
         map_node (List (param, new_children)) acc
     | Label ((x1, param), x2) ->

--- a/src/easy_format.ml
+++ b/src/easy_format.ml
@@ -1,5 +1,22 @@
 open Format
 
+(** Shadow map and split with tailrecursive variants. *)
+module List = struct
+  include List
+  (** Tail recursive of map *)
+  let map f l = List.rev_map f l |> List.rev
+
+  (** Tail recursive version of split *)
+  let split l =
+    let rec inner xs ys = function
+      | (x, y) :: xys ->
+          inner (x::xs) (y::ys) xys
+      | [] -> (xs, ys)
+    in
+    inner [] [] (List.rev l)
+
+end
+
 type wrap = [
   | `Wrap_atoms
   | `Always_wrap

--- a/test/test_easy_format.ml
+++ b/test/test_easy_format.ml
@@ -59,6 +59,16 @@ let make_data list_param label_param atom_param =
     )
   )
 
+(* Test stack overflow *)
+let () =
+  let data =
+    List ( ("[", ",", "]", list),
+           List.init 1_000_000 (fun _i -> Atom ("x", atom))
+         )
+  in
+
+  let (_: string) = Easy_format.Pretty.to_string data in
+  ()
 
 let () =
   let x1 = make_data list label atom in


### PR DESCRIPTION
This PR fixes possible stack overflow, by using a tail recursive function rev_split and use List.rev_map:
 `List.split (List.map aux children)` => `List.rev_split (List.rev_map aux children)` 
The evaluation order in unchanged  so no unexpected behavior should occur even if `aux` has any side effects. 

I also added a test for stack overflow. It will only fail if the stack size is small enough (8M on my system).
